### PR TITLE
feat: implemented update the location of a location provider method

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Following is the current checklist of the implemented schemas and API methods.
 | GET    | `/providers/:providerID`           |     ✅      |
 | PUT    | `/providers/:providerID`           |     ✅      |
 | DELETE | `/providers/:providerID`           |     ✅      |
-| PUT    | `/providers/:providerID/location`  |             |
+| PUT    | `/providers/:providerID/location`  |     ✅      |
 | GET    | `/providers/:providerID/location`  |             |
 | DELETE | `/providers/:providerID/location`  |             |
 | GET    | `/providers/:providerID/fences`    |             |

--- a/cmd/omlox-cli/update.go
+++ b/cmd/omlox-cli/update.go
@@ -19,6 +19,7 @@ func newUpdateCmd(settings cli.EnvSettings, out io.Writer) *cobra.Command {
 
 	cmd.AddCommand(newUpdateTrackablesCmd(settings, out))
 	cmd.AddCommand(newUpdateProvidersCmd(settings, out))
+	cmd.AddCommand(newUpdateProvidersLocationsCmd(settings, out))
 
 	return cmd
 }

--- a/cmd/omlox-cli/update_providers_location.go
+++ b/cmd/omlox-cli/update_providers_location.go
@@ -1,0 +1,79 @@
+// Copyright (c) Omlox Client Go Contributors
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/wavecomtech/omlox-client-go"
+	"github.com/wavecomtech/omlox-client-go/internal/cli"
+	"github.com/wavecomtech/omlox-client-go/internal/cli/resource"
+)
+
+const updateProviderLocationHelp = `
+This command updates location providers locations in the Omlox Hub.
+`
+
+func newUpdateProvidersLocationsCmd(settings cli.EnvSettings, out io.Writer) *cobra.Command {
+	var files []string
+
+	cmd := &cobra.Command{
+		Use:     "providers",
+		Aliases: []string{"location_providers"},
+		Short:   "Update location providers locations in the Hub",
+		Long:    updateProviderLocationHelp,
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var in []io.Reader
+
+			if len(files) > 0 {
+				for _, name := range files {
+					f, err := os.OpenFile(name, os.O_RDONLY, 0444)
+					if err != nil {
+						return err
+					}
+					defer f.Close()
+
+					in = append(in, f)
+				}
+			} else {
+				in = append(in, cmd.InOrStdin())
+			}
+
+			loader := resource.Loader[omlox.Location]{
+				Resources: make([]omlox.Location, 0),
+			}
+			for _, r := range in {
+				if err := loader.LoadJSON(r); err != nil {
+					return err
+				}
+			}
+
+			c, err := newOmloxClient(&settings)
+			if err != nil {
+				return err
+			}
+
+			for _, p := range loader.Resources {
+				err := c.Providers.UpdateLocation(context.Background(), p, p.ProviderID)
+				if err != nil {
+					return err
+				}
+
+				fmt.Fprintf(out, "updated: %v location\n", p.ProviderID)
+			}
+
+			return nil
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringArrayVarP(&files, "file", "f", []string{}, "The files that contain the location providers locations to update")
+
+	return cmd
+}

--- a/cmd/omlox-cli/update_providers_location.go
+++ b/cmd/omlox-cli/update_providers_location.go
@@ -23,8 +23,8 @@ func newUpdateProvidersLocationsCmd(settings cli.EnvSettings, out io.Writer) *co
 	var files []string
 
 	cmd := &cobra.Command{
-		Use:     "providers",
-		Aliases: []string{"location_providers"},
+		Use:     "providers_locations",
+		Aliases: []string{"location_providers_locations"},
 		Short:   "Update location providers locations in the Hub",
 		Long:    updateProviderLocationHelp,
 		Args:    cobra.ExactArgs(0),

--- a/docs/cli/omlox_update.md
+++ b/docs/cli/omlox_update.md
@@ -19,5 +19,6 @@ Update hub resources
 
 * [omlox](omlox.md)	 - The Omlox Hub CLI tool
 * [omlox update providers](omlox_update_providers.md)	 - Update location providers in the Hub
+* [omlox update providers](omlox_update_providers.md)	 - Update location providers locations in the Hub
 * [omlox update trackables](omlox_update_trackables.md)	 - Update trackables in the Hub
 

--- a/docs/cli/omlox_update.md
+++ b/docs/cli/omlox_update.md
@@ -19,6 +19,6 @@ Update hub resources
 
 * [omlox](omlox.md)	 - The Omlox Hub CLI tool
 * [omlox update providers](omlox_update_providers.md)	 - Update location providers in the Hub
-* [omlox update providers](omlox_update_providers.md)	 - Update location providers locations in the Hub
+* [omlox update providers_locations](omlox_update_providers_locations.md)	 - Update location providers locations in the Hub
 * [omlox update trackables](omlox_update_trackables.md)	 - Update trackables in the Hub
 

--- a/docs/cli/omlox_update_providers.md
+++ b/docs/cli/omlox_update_providers.md
@@ -1,11 +1,11 @@
 ## omlox update providers
 
-Update location providers in the Hub
+Update location providers locations in the Hub
 
 ### Synopsis
 
 
-This command updates location providers in the Omlox Hub.
+This command updates location providers locations in the Omlox Hub.
 
 
 ```
@@ -15,7 +15,7 @@ omlox update providers [flags]
 ### Options
 
 ```
-  -f, --file stringArray   The files that contain the location providers to update
+  -f, --file stringArray   The files that contain the location providers locations to update
   -h, --help               help for providers
 ```
 

--- a/docs/cli/omlox_update_providers.md
+++ b/docs/cli/omlox_update_providers.md
@@ -1,11 +1,11 @@
 ## omlox update providers
 
-Update location providers locations in the Hub
+Update location providers in the Hub
 
 ### Synopsis
 
 
-This command updates location providers locations in the Omlox Hub.
+This command updates location providers in the Omlox Hub.
 
 
 ```
@@ -15,7 +15,7 @@ omlox update providers [flags]
 ### Options
 
 ```
-  -f, --file stringArray   The files that contain the location providers locations to update
+  -f, --file stringArray   The files that contain the location providers to update
   -h, --help               help for providers
 ```
 

--- a/docs/cli/omlox_update_providers_locations.md
+++ b/docs/cli/omlox_update_providers_locations.md
@@ -1,0 +1,32 @@
+## omlox update providers_locations
+
+Update location providers locations in the Hub
+
+### Synopsis
+
+
+This command updates location providers locations in the Omlox Hub.
+
+
+```
+omlox update providers_locations [flags]
+```
+
+### Options
+
+```
+  -f, --file stringArray   The files that contain the location providers locations to update
+  -h, --help               help for providers_locations
+```
+
+### Options inherited from parent commands
+
+```
+      --addr string   omlox hub API endpoint (default "localhost:8081")
+      --debug         enable debug logging
+```
+
+### SEE ALSO
+
+* [omlox update](omlox_update.md)	 - Update hub resources
+

--- a/provider_requests.go
+++ b/provider_requests.go
@@ -123,3 +123,20 @@ func (c *ProvidersAPI) Delete(ctx context.Context, id string) error {
 
 	return err
 }
+
+// UpdateLocation updates the location of a location provider.
+func (c *ProvidersAPI) UpdateLocation(ctx context.Context, location Location, id string) error {
+	requestPath := "/providers/" + id + "/location"
+
+	_, err := sendStructuredRequestParseResponse[struct{}](
+		ctx,
+		c.client,
+		http.MethodPut,
+		requestPath,
+		location,
+		nil, // request query parameters
+		nil, // request headers
+	)
+
+	return err
+}


### PR DESCRIPTION
The omlox-client-go package is still missing some method implementations. This pull request aims to implement the following ones:
- **PUT** `/providers/:providerID/location`